### PR TITLE
Updated licence in README (from MIT to GNU/GPL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ Please make sure to update tests as appropriate.
 
 ## License
 
-[MIT](https://choosealicense.com/licenses/mit/)
+[GNU/GPL](http://www.gnu.org/copyleft/gpl.html)


### PR DESCRIPTION
Updated licence in README (from MIT to GNU/GPL) because of licensing of original PHP script.